### PR TITLE
Support for returning only metadata, accepting fields to filter, and fix the bigint parsing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The app is now running, navigate to http://localhost:3000/ in your browser to ex
 All the Next.js API routes are defined under `pages/api/`. We have following
 files exposing endpoints:
 
-- `/api/search?q={searchString}&page={page}&size={size}&order={order}`: Search sessions
+- `/api/items/search?q={searchString}&page={page}&size={size}&order={order}`: Search sessions
   - Query Parameters
     - `searchString` (required): This searches sessions by `record.*`
     - `size` (optional): This specifies how many sessions should be returned in
@@ -36,8 +36,20 @@ files exposing endpoints:
       there are more than one page of search results
     - `order` (optional): The sort order for results in either ascending or
       descending order. The value can either `asc` or `desc`
+    - `dateStart` (optional): This specifies the session timestamp which is 
+      used to filter the matched sessions so that only the ones created on 
+      or after this date are returned
+    - `dateEnd` (optional): This specifies the session timestamp which is
+      used to filter the matched sessions so that only the ones created on
+      or before this date are returned
+    - `metaOnly` (optional): When set only the metadata is returned 
+      corresponding to the search and not the matched sessions
+    - `searchFields` (optional): This specifies the fields to perform the 
+      search on. By default all the fields are used to perform the search
   - Example
     - `curl http://localhost:3000/api/items/search?q=chrome&size=1`
+    - `curl http://localhost:3000/api/items/search?q=ed&size=1&searchFields=record.browser`
+    - `curl http://localhost:3000/api/items/search?q=chrome&metaOnly=true`
 
 <details>
 <summary>Expand for a code walkthrough</summary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,14 @@
         "@tigrisdata/core": "latest",
         "@tremor/react": "^1.8.2",
         "heroicons": "^1.0.6",
-        "json-bigint": "^1.0.0",
+        "json-bigint": "github:sidorares/json-bigint",
         "moment": "^2.29.4",
         "next": "^13.0.6",
         "react": "^18.2.0",
         "react-data-table-component": "^7.5.3",
         "react-dom": "^18.2.0",
         "react-simple-maps": "^3.0.0",
+        "react-spinners": "^0.13.8",
         "react-tooltip": "^5.9.1",
         "reflect-metadata": "^0.1.13",
         "stream-json": "^1.7.5"
@@ -4028,8 +4029,8 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "resolved": "git+ssh://git@github.com/sidorares/json-bigint.git#3391780b2a3f613bb51536c47e6cddbca31013eb",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -4992,6 +4993,15 @@
       "peerDependencies": {
         "react": ">=15.0.0",
         "react-dom": ">=15.0.0"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-tooltip": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@tigrisdata/core": "latest",
     "@tremor/react": "^1.8.2",
     "heroicons": "^1.0.6",
-    "json-bigint": "^1.0.0",
+    "json-bigint": "github:sidorares/json-bigint",
     "moment": "^2.29.4",
     "next": "^13.0.6",
     "react": "^18.2.0",


### PR DESCRIPTION
Add support for returning only the metadata, accepting fields to filter on as well as fixing the bug with bigint parsing.

- `curl http://localhost:3000/api/items/search?q=chrome&size=1`
- `curl http://localhost:3000/api/items/search?q=ed&size=1&searchFields=record.browser`
- `curl http://localhost:3000/api/items/search?q=chrome&metaOnly=true`